### PR TITLE
Bugfixes from TSM

### DIFF
--- a/ansible/ansible-workshop/data-dependencies.yml
+++ b/ansible/ansible-workshop/data-dependencies.yml
@@ -29,6 +29,7 @@
         dest: /mnt/data/workshop/raster-vision
         version: foss4g
         clone: yes
+        force: yes
 
     - name: Pull Raster Vision container
       shell: |

--- a/upload-script/HITL_upload.ipynb
+++ b/upload-script/HITL_upload.ipynb
@@ -856,7 +856,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "MODEL_INIT_WEIGHTS_PATH = \"./init_weights.pth\"\n",
+    "MODEL_INIT_WEIGHTS_PATH = \"../init_weights.pth\"\n",
     "OUTPUT_ROOT = \"./output\"\n",
     "RV_CONFIG_FILE = \"./active_learning.py\"\n",
     "\n",

--- a/upload-script/HITL_upload.ipynb
+++ b/upload-script/HITL_upload.ipynb
@@ -747,7 +747,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!unzip -d export-data/iter-{last_iter}/ export-data/iter-{last_iter}/stac-export.zip"
+    "!unzip -d export-data/iter-{iter_num}/ export-data/iter-{iter_num}/stac-export.zip"
    ]
   },
   {

--- a/upload-script/active_learning.py
+++ b/upload-script/active_learning.py
@@ -12,7 +12,7 @@ from rastervision.pytorch_backend import *
 from rastervision.pytorch_learner import *
 from rastervision.pytorch_backend.examples.utils import read_stac
 
-image_uri = './jacksonville.sub.tif'
+image_uri = '../jacksonville.sub.tif'
 
 
 def get_config(runner, output_dir: str, stac_export_uri: str,


### PR DESCRIPTION
This PR fixes a few things that went a little wrong in the TSM:

- adds `force` to the git command to fetch the repo, so that even running servers can have their repo contents updated
- fixes the paths referring to the tif and initial model weights for what's actually configured by ansible
- changes `last_iter` to `iter_num` in the optional `unzip` command