### PR TITLE
Fix bug with RV training encountered during workshop

### DIFF
--- a/upload-script/active_learning.py
+++ b/upload-script/active_learning.py
@@ -36,7 +36,7 @@ def get_config(runner, output_dir: str, stac_export_uri: str,
         'val_stac_export_uri',
         '../validation-export.zip')
     val_stac_unzip_dir = f'./tmp/val/{Path(val_stac_export_uri).stem}'
-    val_scene_infos = read_stac(stac_export_uri, val_stac_unzip_dir)
+    val_scene_infos = read_stac(val_stac_export_uri, val_stac_unzip_dir)
 
     chip_sz = int(kwargs.get('chip_sz', 300))
 


### PR DESCRIPTION
This typo was the cause of the bug with RV training encountered during the workshop. For the validation scene, we were incorrectly using labels inside the training export with the validation image. So it only worked for people who happened to have validated a GW task inside the validation scene's extent.